### PR TITLE
Fix fuel refill callback

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -224,12 +224,13 @@ local refillVehicleFuel = function (liter)
         disableMouse = false,
         disableCombat = true,
     }, {}, {}, {}, function()
-        local success = QBCore.Functions.TriggerCallback('qb-fuel:server:refillVehicle', liter)
-        if not success then return QBCore.Functions.Notify(Lang:t('error.no_money'), 'error') end
-        removeObjects()
-        exports['qb-fuel']:SetFuel(veh, math.floor(exports['qb-fuel']:GetFuel(veh) or 0) + liter)
-        QBCore.Functions.Notify(Lang:t('success.refueled'), 'success')
-        ClearPedTasks(ped)
+        QBCore.Functions.TriggerCallback('qb-fuel:server:refillVehicle', function(success)
+            if not success then return QBCore.Functions.Notify(Lang:t('error.no_money'), 'error') end
+            removeObjects()
+            exports['qb-fuel']:SetFuel(veh, math.floor(exports['qb-fuel']:GetFuel(veh) or 0) + liter)
+            QBCore.Functions.Notify(Lang:t('success.refueled'), 'success')
+            ClearPedTasks(ped)
+        end, liter)
     end, function()
         removeObjects()
     end)


### PR DESCRIPTION
## Summary
- fix fuel refill to use async callback

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b7efa7cd0832997494657a40a1087