### PR TITLE
Fix lint issues in fuel scripts

### DIFF
--- a/client/exports.lua
+++ b/client/exports.lua
@@ -46,7 +46,7 @@ if Config.SyncFuelBetweenPlayers then
                     Entity(vehicle).state:set('qb-fuel', GetVehicleFuelLevel(vehicle) + 0.0, true)
                 end
                 Wait(Config.FuelSyncTime*1000)
-            end 
+            end
         end)
     end)
 
@@ -64,7 +64,7 @@ if Config.SyncFuelBetweenPlayers then
                     Entity(vehicle).state:set('qb-fuel', fuel + 0.0, true)
                 end
                 Wait(Config.FuelSyncTime*1000)
-            end 
+            end
         end)
     end)
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -16,7 +16,7 @@ end
 
 local removeObjects = function ()
     CurrentPump = nil
-    if CurrentVehicle then 
+    if CurrentVehicle then
         Entity(CurrentVehicle).state:set('nozzleAttached', false, true)
         FreezeEntityPosition(CurrentVehicle, false)
         CurrentVehicle = nil
@@ -174,7 +174,6 @@ local nozzleToVehicle = function (veh)
     local zCoords = diff / divisor
 
     LocalPlayer.state:set('hasNozzle', false, true)
-    local ped = PlayerPedId()
 
     if isBike then
         AttachEntityToEntity(CurrentObjects.nozzle, veh, tankBone, 0.0 + nozzleModifiedPosition.x, -0.2 + nozzleModifiedPosition.y, 0.2 + nozzleModifiedPosition.z, -80.0, 0.0, 0.0, true, true, false, false, 1, true)

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -28,6 +28,7 @@ local Translations = {
     }
 }
 
+local Locale = Locale
 Lang = Lang or Locale:new({
     phrases = Translations,
     warnOnMissing = true

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -29,9 +29,11 @@ local Translations = {
 }
 
 if GetConvar('qb_locale', 'en') == 'es' then
+    local Locale = Locale
     Lang = Locale:new({
         phrases = Translations,
         warnOnMissing = true,
         --fallbackLang = Lang,
     })
 end
+

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -29,6 +29,7 @@ local Translations = {
 }
 
 if GetConvar('qb_locale', 'en') == 'nl' then
+    local Locale = Locale
     Lang = Locale:new({
         phrases = Translations,
         warnOnMissing = true,


### PR DESCRIPTION
## Summary
- trim trailing whitespace in exports
- remove unused variable in main.lua
- allow Locale global for translations

## Testing
- `git diff --cached --stat`


------
https://chatgpt.com/codex/tasks/task_e_684b7f411e108329ad838ebad460a38c