### PR TITLE
Fix Locale lint warnings

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals Lang Locale
 local Translations = {
     progress = {
         refueling = 'Refueling...',
@@ -28,7 +29,6 @@ local Translations = {
     }
 }
 
-local Locale = Locale
 Lang = Lang or Locale:new({
     phrases = Translations,
     warnOnMissing = true

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals Lang Locale
 local Translations = {
     progress = {
         refueling = 'Repostando Vehículo...',
@@ -29,7 +30,6 @@ local Translations = {
 }
 
 if GetConvar('qb_locale', 'en') == 'es' then
-    local Locale = Locale
     Lang = Locale:new({
         phrases = Translations,
         warnOnMissing = true,

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals Lang Locale
 local Translations = {
     progress = {
         refueling = 'Voertuig aan het voltanken...',
@@ -29,7 +30,6 @@ local Translations = {
 }
 
 if GetConvar('qb_locale', 'en') == 'nl' then
-    local Locale = Locale
     Lang = Locale:new({
         phrases = Translations,
         warnOnMissing = true,


### PR DESCRIPTION
## Summary
- satisfy linting by declaring global `Locale`
- adjust translation files to remove redundant reassignment

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b81152384832983548a56cd560151